### PR TITLE
🌱 Update KAL and restore required field tags

### DIFF
--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -25,22 +25,22 @@ linters:
               #- "nobools" # Bools do not evolve over time, should use enums instead.
               #- "nofloats" # Ensure floats are not used.
               #- "optionalorrequired" # Every field should be marked as `+optional` or `+required`.
-              # - "requiredfields" # Required fields should not be pointers, and should not have `omitempty`.
+              - "requiredfields" # Required fields should not be pointers and should have `omitempty`.
               - "statussubresource" # All root objects that have a `status` field should have a status subresource.
 
             # Linters below this line are disabled, pending conversation on how and when to enable them.
             disable:
               - "*" # We will manually enable new linters after understanding the impact. Disable all by default.
-          lintersConfig:
-            conditions:
-              isFirstField: Warn # Require conditions to be the first field in the status struct.
-              usePatchStrategy: Forbid # Conditions should not use the patch strategy on CRDs.
-              useProtobuf: Forbid # We don't use protobuf, so protobuf tags are not required.
+          # lintersConfig:
+          #   conditions:
+          #     isFirstField: Warn # Require conditions to be the first field in the status struct.
+          #     usePatchStrategy: Forbid # Conditions should not use the patch strategy on CRDs.
+          #     useProtobuf: Forbid # We don't use protobuf, so protobuf tags are not required.
           # jsonTags:
           #   jsonTagRegex: "^[a-z][a-z0-9]*(?:[A-Z][a-z0-9]*)*$" # The default regex is appropriate for our use case.
-          # optionalOrRequired:
-          #   preferredOptionalMarker: optional | kubebuilder:validation:Optional # The preferred optional marker to use, fixes will suggest to use this marker. Defaults to `optional`.
-          #   preferredRequiredMarker: required | kubebuilder:validation:Required # The preferred required marker to use, fixes will suggest to use this marker. Defaults to `required`.
+            # optionalOrRequired:
+            #   preferredOptionalMarker: optional | kubebuilder:validation:Optional # The preferred optional marker to use, fixes will suggest to use this marker. Defaults to `optional`.
+            #   preferredRequiredMarker: required | kubebuilder:validation:Required # The preferred required marker to use, fixes will suggest to use this marker. Defaults to `required`.
           # requiredFields:
           #   pointerPolicy: Warn | SuggestFix # Defaults to `SuggestFix`. We want our required fields to not be pointers.
 

--- a/exp/api/v1beta2/rosamachinepool_types.go
+++ b/exp/api/v1beta2/rosamachinepool_types.go
@@ -74,7 +74,8 @@ type RosaMachinePoolSpec struct {
 	// InstanceType specifies the AWS instance type
 	//
 	// +kubebuilder:validation:Required
-	InstanceType string `json:"instanceType"`
+	// +kubebuilder:validation:MinLength=1
+	InstanceType string `json:"instanceType,omitempty"`
 
 	// Autoscaling specifies auto scaling behaviour for this MachinePool.
 	// required if Replicas is not configured
@@ -125,7 +126,8 @@ type RosaTaint struct {
 	// The taint key to be applied to a node.
 	//
 	// +kubebuilder:validation:Required
-	Key string `json:"key"`
+	// +kubebuilder:validation:MinLength=1
+	Key string `json:"key,omitempty"`
 	// The taint value corresponding to the taint key.
 	//
 	// +kubebuilder:validation:Pattern:=`^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$`
@@ -136,7 +138,7 @@ type RosaTaint struct {
 	//
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Enum=NoSchedule;PreferNoSchedule;NoExecute
-	Effect corev1.TaintEffect `json:"effect"`
+	Effect corev1.TaintEffect `json:"effect,omitempty"`
 }
 
 // RosaMachinePoolAutoScaling specifies scaling options.

--- a/exp/api/v1beta2/types.go
+++ b/exp/api/v1beta2/types.go
@@ -52,6 +52,7 @@ type EBS struct {
 type BlockDeviceMapping struct {
 	// The device name exposed to the EC2 instance (for example, /dev/sdh or xvdh).
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
 	DeviceName string `json:"deviceName,omitempty"`
 
 	// You can specify either VirtualName or Ebs, but not both.
@@ -339,13 +340,15 @@ type Taint struct {
 	// Effect specifies the effect for the taint
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Enum=no-schedule;no-execute;prefer-no-schedule
-	Effect TaintEffect `json:"effect"`
+	Effect TaintEffect `json:"effect,omitempty"`
 	// Key is the key of the taint
 	// +kubebuilder:validation:Required
-	Key string `json:"key"`
+	// +kubebuilder:validation:MinLength=1
+	Key string `json:"key,omitempty"`
 	// Value is the value of the taint
 	// +kubebuilder:validation:Required
-	Value string `json:"value"`
+	// +kubebuilder:validation:MinLength=1
+	Value string `json:"value,omitempty"`
 }
 
 // Equals is used to test if 2 taints are equal.

--- a/hack/tools/.custom-gcl.yaml
+++ b/hack/tools/.custom-gcl.yaml
@@ -3,4 +3,4 @@ name: golangci-lint-kube-api-linter
 destination: ./bin
 plugins:
 - module: 'sigs.k8s.io/kube-api-linter'
-  version: v0.0.0-20250411141643-33ef95a5ee04
+  version: v0.0.0-20250902135116-ef33eac3b92b


### PR DESCRIPTION
## Summary
- update kube-api-linter to the latest commit
- restore `omitempty` on required fields and add missing min length validations

## Testing
- `hack/tools/bin/golangci-lint-kube-api-linter run -v --timeout 2m --config .golangci-kal.yml` *(fails: requiredfields warnings in exp/api/v1beta2)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_b_68b750a4b62c832283174fd2530db482